### PR TITLE
Fix for emoji version 2.0.0

### DIFF
--- a/chatline.py
+++ b/chatline.py
@@ -114,11 +114,7 @@ class Chatline:
         return words
 
     def extract_emojis(self, string=""):
-        emj = []
-        for c in string:
-            if c in emoji.UNICODE_EMOJI_ALIAS_ENGLISH:
-                emj.append(c)
-        return emj
+        return [c["emoji"] for c in emoji.emoji_list(string)]
 
     def is_event(self, body=""):
         """Detect wether the body of chat is event log.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-dateutil
-emoji
+emoji>=1.7.0


### PR DESCRIPTION
The property `emoji.UNICODE_EMOJI_ALIAS_ENGLISH` was removed in version 2.0.0 of emoji module.
From version 1.7.0 and later there is a function `emoji.emoji_list()` to find emoji in a string, that can be used as a replacement.

Fixes #19
