### PR TITLE
use strict date format for parsing

### DIFF
--- a/chatline.py
+++ b/chatline.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
-from dateutil import parser
+from datetime import datetime
 import emoji
 import patterns
 
@@ -90,7 +90,7 @@ class Chatline:
         """
         EXTRACT TIMESTAMP
         """
-        timestamp = parser.parse(time_string)
+        timestamp = datetime.strptime(time_string, "%d/%m/%Y, %H:%M:%S")
         return timestamp
 
     def extract_url(self, body=""):


### PR DESCRIPTION
Fixes #22

I believe WhatsApp logs always have the same YYY-MM-DD format, so parsing it like this shouldn't cause any issues and fixes the bug I was encountering 